### PR TITLE
Adds a struct to Bankster.Bic

### DIFF
--- a/lib/bankster/bic.ex
+++ b/lib/bankster/bic.ex
@@ -1,23 +1,164 @@
 defmodule Bankster.Bic do
   @moduledoc """
   Module provides some SWIFT BIC related functions.
+
+  See: https://en.wikipedia.org/wiki/ISO_9362
   """
 
-  ## -- Module attributes
-  @bic_validation_regex ~r/^([a-zA-Z]){4}([a-zA-Z]){2}([0-9a-zA-Z]){2}([0-9a-zA-Z]{3})?$/
+  defstruct [:bank, :country, :location, :branch]
 
-  ## -- Functions
+  @type t :: %__MODULE__{
+          bank: binary(),
+          country: binary(),
+          location: binary(),
+          branch: binary() | nil
+        }
+
+  @bic_regex ~r/^(?<bank>[a-zA-Z]{4})\s*(?<country>[a-zA-Z]{2})\s*(?<location>[0-9a-zA-Z]{2})\s*(?<branch>[0-9a-zA-Z]{3})?$/
+
   @doc """
-  Validates a given string whether it's a valid SWIFT BIC
+  Parses a BIC string into its components.
+
+  ## Examples
+    iex> Bankster.Bic.parse("INVALIDBIC")
+    :error
+
+    iex> Bankster.Bic.parse("AAAABBCC123")
+    %Bankster.Bic{bank: "AAAA", country: "BB", location: "CC", branch: "123"}
+
+    iex> Bankster.Bic.parse("AAAABBCC")
+    %Bankster.Bic{bank: "AAAA", country: "BB", location: "CC", branch: nil}
+
+    iex> Bankster.Bic.parse("AAAA BB CC 123")
+    %Bankster.Bic{bank: "AAAA", country: "BB", location: "CC", branch: "123"}
+
+    iex> Bankster.Bic.parse("AAAA BB CC")
+    %Bankster.Bic{bank: "AAAA", country: "BB", location: "CC", branch: nil}
+
+    iex> Bankster.Bic.parse("AAAA BB CC     123")
+    %Bankster.Bic{bank: "AAAA", country: "BB", location: "CC", branch: "123"}
+  """
+  @spec parse(term()) :: {:ok, t()} | :error
+  def parse(bic) when is_binary(bic) do
+    case Regex.named_captures(@bic_regex, bic) do
+      nil ->
+        :error
+
+      captures ->
+        {
+          :ok,
+          %__MODULE__{
+            bank: captures["bank"],
+            country: captures["country"],
+            location: captures["location"],
+            branch: presence(captures["branch"])
+          }
+        }
+    end
+  end
+
+  def parse(_), do: :error
+
+  @doc """
+  Parses a BIC string into its components.
+
+  Will raise `ArgumentError` if the value can not be parsed.
+  """
+  @spec parse!(term()) :: t()
+  def parse!(bic) do
+    case parse(bic) do
+      {:ok, parsed} ->
+        parsed
+
+      :error ->
+        raise ArgumentError, message: "invalid argument bic: #{inspect(bic)}"
+    end
+  end
+
+  @doc """
+  Turns a `Bankster.Bic` into a string.
+
+  ## Options
+
+  * `:format` - Specifies the format to use when encoding.
+  * `:case` - Specifies the character case when encoding.
+
+  The values for `:format` can be:
+
+  * `:compact` - No spaces between components. (default)
+  * `:pretty` - Adds spaces between components
+
+  The values for `:case` can be:
+
+  * `:upper` - All characters are made to be upper case. (default)
+  * `:lower` - All characters are made to be lower case.
+  * `:leave` - Leaves the characters in the case they are in.
+  """
+  @spec to_string(t()) :: binary()
+  @spec to_string(t(), [{:format, :pretty | :compact}]) :: binary()
+  def to_string(
+        %__MODULE__{bank: bank, country: country, location: location, branch: branch} = bic,
+        opts \\ []
+      ) do
+    if bank == nil do
+      raise ArgumentError, ":bank is required, got: #{inspect(bic)}"
+    end
+
+    if country == nil do
+      raise ArgumentError, ":country is required, got: #{inspect(bic)}"
+    end
+
+    if location == nil do
+      raise ArgumentError, ":location is required, got: #{inspect(bic)}"
+    end
+
+    string =
+      case opts[:format] do
+        :pretty ->
+          if branch do
+            "#{bank} #{country} #{location} #{branch}"
+          else
+            "#{bank} #{country} #{location}"
+          end
+
+        _ ->
+          "#{bank}#{country}#{location}#{branch}"
+      end
+
+    case opts[:case] do
+      :leave -> string
+      :lower -> String.downcase(string)
+      _ -> String.upcase(string)
+    end
+  end
+
+  @doc """
+  Validates a given string whether it's a valid SWIFT BIC.
+
+  > #### Note {: .info}
+  > This ignores whitespace between the components.
 
   ## Examples
     iex> Bankster.Bic.valid?("INVALIDBIC")
     false
+
+    iex> Bankster.Bic.valid?("AAAABBCC123")
+    true
+
+    iex> Bankster.Bic.valid?("AAAABBCC")
+    true
+
+    iex> Bankster.Bic.valid?("AAAA BB CC 123")
+    true
   """
   @spec valid?(binary()) :: boolean()
-  def valid?(bic) when is_binary(bic),
-    do: Regex.match?(@bic_validation_regex, String.replace(bic, ~r/\s*/, ""))
+  def valid?(bic) when is_binary(bic), do: Regex.match?(@bic_regex, bic)
+  def valid?(_), do: false
 
-  def valid?(_),
-    do: false
+  defp presence(""), do: nil
+  defp presence(val), do: val
+end
+
+defimpl String.Chars, for: Bankster.Bic do
+  defdelegate to_string(bic), to: Bankster.Bic
 end

--- a/test/bankster/bic_test.exs
+++ b/test/bankster/bic_test.exs
@@ -1,24 +1,150 @@
 defmodule Bankster.Bic.BicTest do
   use ExUnit.Case
 
-  ## -- Module constants
+  alias Bankster.Bic
+
   @valid_bics [
     "RBOSGGSX",
+    "RBOS GG SX",
+    "RBOS GGSX",
+    "RBOSGG SX",
     "RZTIAT22263",
+    "RZTI AT 22 263",
+    "RZTI AT 22263",
+    "RZTI AT22263",
+    "RZTIAT22 263",
+    "RZTI  AT  22263",
     "BCEELULL",
     "MARKDEFF",
     "GENODEF1JEV",
     "UBSWCHZH80A",
     "CEDELULLXXX"
   ]
-  @invalid_bics ["CE1EL2LLFFF", "E31DCLLFFF", "", " ", nil]
 
-  ## -- Test cases
-  test "valid?/1" do
-    ## -- VALID BICS
-    for bic <- @valid_bics, do: assert(Bankster.Bic.valid?(bic) == true)
+  @invalid_bics ["CE1EL2LLFFF", "E31DCLLFFF", "", " ", nil, "INVALIDBIC"]
 
-    ## -- INVALID BICS
-    for bic <- @invalid_bics, do: assert(Bankster.Bic.valid?(bic) == false)
+  describe "valid?" do
+    test "valid bics" do
+      for bic <- @valid_bics, do: assert(Bic.valid?(bic) == true)
+    end
+
+    test "invalid bics" do
+      for bic <- @invalid_bics, do: assert(Bic.valid?(bic) == false)
+    end
+  end
+
+  describe "parse" do
+    test "invalid bics" do
+      for bic <- @invalid_bics do
+        assert :error = Bic.parse(bic)
+      end
+
+      assert :error = Bic.parse("  AAAABBCC123")
+      assert :error = Bic.parse(nil)
+      assert :error = Bic.parse(~D[2020-01-01])
+    end
+
+    test "valid bics" do
+      for bic <- @valid_bics do
+        assert {:ok, _} = Bic.parse(bic)
+      end
+
+      assert {:ok, bic} = Bic.parse("RBOSGGSX")
+      assert %{bank: "RBOS", country: "GG", location: "SX", branch: nil} = bic
+
+      assert {:ok, bic} = Bic.parse("RZTIAT22263")
+      assert %Bic{bank: "RZTI", country: "AT", location: "22", branch: "263"} = bic
+
+      assert {:ok, bic} = Bic.parse("RZTIAT22 263")
+      assert %Bic{bank: "RZTI", country: "AT", location: "22", branch: "263"} = bic
+
+      assert {:ok, bic} = Bic.parse("RZTIAT 22 263")
+      assert %Bic{bank: "RZTI", country: "AT", location: "22", branch: "263"} = bic
+
+      assert {:ok, bic} = Bic.parse("RZTI AT22 263")
+      assert %Bic{bank: "RZTI", country: "AT", location: "22", branch: "263"} = bic
+
+      assert {:ok, bic} = Bic.parse("BCEELULL")
+      assert %Bic{bank: "BCEE", country: "LU", location: "LL", branch: nil} = bic
+
+      assert {:ok, bic} = Bic.parse("MARKDEFF")
+      assert %Bic{bank: "MARK", country: "DE", location: "FF", branch: nil} = bic
+
+      assert {:ok, bic} = Bic.parse("MARK DE FF")
+      assert %Bic{bank: "MARK", country: "DE", location: "FF", branch: nil} = bic
+
+      assert {:ok, bic} = Bic.parse("MARK DEFF")
+      assert %Bic{bank: "MARK", country: "DE", location: "FF", branch: nil} = bic
+
+      assert {:ok, bic} = Bic.parse("MARKDE FF")
+      assert %Bic{bank: "MARK", country: "DE", location: "FF", branch: nil} = bic
+
+      assert {:ok, bic} = Bic.parse("MARK   DE   FF")
+      assert %Bic{bank: "MARK", country: "DE", location: "FF", branch: nil} = bic
+
+      assert {:ok, bic} = Bic.parse("markdeff")
+      assert %Bic{bank: "mark", country: "de", location: "ff", branch: nil} = bic
+    end
+  end
+
+  describe "parse!" do
+    test "valid bic" do
+      assert %Bic{
+               bank: "mark",
+               country: "de",
+               location: "ff",
+               branch: nil
+             } = Bic.parse!("markdeff")
+    end
+
+    test "invalid bic raises an argument error" do
+      assert_raise(ArgumentError, ~s(invalid argument bic: "CE1EL2LLFFF"), fn ->
+        Bic.parse!("CE1EL2LLFFF")
+      end)
+    end
+  end
+
+  describe "to_string" do
+    test "formatting options" do
+      bic11 = %Bic{bank: "AaAa", country: "bB", location: "cC", branch: "123"}
+      bic8 = %Bic{bank: "AaAa", country: "bB", location: "cC", branch: nil}
+
+      assert "AAAABBCC123" == Bic.to_string(bic11)
+      assert "AAAABBCC123" == Bic.to_string(bic11, case: :upper)
+      assert "aaaabbcc123" == Bic.to_string(bic11, case: :lower)
+      assert "AaAabBcC123" == Bic.to_string(bic11, case: :leave)
+      assert "AAAABBCC123" == Bic.to_string(bic11, case: :upper, format: :compact)
+      assert "aaaabbcc123" == Bic.to_string(bic11, case: :lower, format: :compact)
+      assert "AaAabBcC123" == Bic.to_string(bic11, case: :leave, format: :compact)
+      assert "AAAA BB CC 123" == Bic.to_string(bic11, case: :upper, format: :pretty)
+      assert "aaaa bb cc 123" == Bic.to_string(bic11, case: :lower, format: :pretty)
+      assert "AaAa bB cC 123" == Bic.to_string(bic11, case: :leave, format: :pretty)
+
+      assert "AAAABBCC" == Bic.to_string(bic8)
+      assert "AAAABBCC" == Bic.to_string(bic8, case: :upper)
+      assert "aaaabbcc" == Bic.to_string(bic8, case: :lower)
+      assert "AaAabBcC" == Bic.to_string(bic8, case: :leave)
+      assert "AAAABBCC" == Bic.to_string(bic8, case: :upper, format: :compact)
+      assert "aaaabbcc" == Bic.to_string(bic8, case: :lower, format: :compact)
+      assert "AaAabBcC" == Bic.to_string(bic8, case: :leave, format: :compact)
+      assert "AAAA BB CC" == Bic.to_string(bic8, case: :upper, format: :pretty)
+      assert "aaaa bb cc" == Bic.to_string(bic8, case: :lower, format: :pretty)
+      assert "AaAa bB cC" == Bic.to_string(bic8, case: :leave, format: :pretty)
+
+      assert "AAAABBCC123" == String.Chars.to_string(bic11)
+      assert "AAAABBCC" == String.Chars.to_string(bic8)
+
+      assert_raise(ArgumentError, ~r/:bank is required, got:/, fn ->
+        String.Chars.to_string(%Bic{bank: nil, country: "BB", location: "CC", branch: "123"})
+      end)
+
+      assert_raise(ArgumentError, ~r/:country is required, got:/, fn ->
+        String.Chars.to_string(%Bic{bank: "AAAA", country: nil, location: "CC", branch: "123"})
+      end)
+
+      assert_raise(ArgumentError, ~r/:location is required, got:/, fn ->
+        String.Chars.to_string(%Bic{bank: "AAAA", country: "BB", location: nil, branch: "123"})
+      end)
+    end
   end
 end


### PR DESCRIPTION
* Uses regex named capture to extract the data.
* Handles 8-11 BIC values.
* Adds a `to_string/2` function for pretty output.
* Defines the `String.Chars` protocol for `Bic`.